### PR TITLE
Resolve Problem in opening random file !

### DIFF
--- a/CUTE/src/io.c
+++ b/CUTE/src/io.c
@@ -189,7 +189,7 @@ void read_RR(char *fname,histo_t *R1R2)
 #endif
   print_info("\n");
 
-  fi=fopen(fname,"w");
+  fi=fopen(fname,"r");
   if(fi==NULL)
     error_open_file(fname);
 


### PR DESCRIPTION
Hi, 

I notice an error when I want to use a previous calculation of RR. (RR_filename= previous_ang_corr_with_CUTE.txt). The file is erased when it is opened.

`fopen(file, 'w')`  seems to erase the content of the file [(see here)](https://koor.fr/C/cstdio/fopen.wp) ... change 'w' --> 'r' to just read the content and not to erase it before reading